### PR TITLE
fix(config): use more agnostic MCP configuratio

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,10 +6,10 @@ import asyncio
 mcp_server_config = {
     "mcpServers": {
         "kestraPython": {
-            "command": "/Users/annageller/.local/bin/uv",
+            "command": "uv",
             "args": [
                 "--directory",
-                "/Users/annageller/gh/mcp-server-python/src",
+                "src",
                 "run",
                 "server.py",
             ],


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5908e550-c797-496e-9c66-fba2b49a3e0d)


Following flow work nicely; only one test that fail. I will evaluate deeper and likely create another PR (or open an issue on Kestra repository if it's actually a regression bug)

```yaml
id: mcp_tests_docker
namespace: dev.ben

tasks:
  - id: git
    type: io.kestra.plugin.git.SyncNamespaceFiles
    url: https://github.com/kestra-io/mcp-server-python
    branch: fix/tests
    namespace: dev.ben
    gitDirectory: ./
      
  - id: ee_develop
    type: io.kestra.plugin.scripts.python.Commands
    containerImage: ghcr.io/kestra-io/mcp-server-python:latest
    inputFiles:
      .env: |
        KESTRA_BASE_URL=xxx
        KESTRA_TENANT_ID=xxx
        KESTRA_API_TOKEN=xxx
        GOOGLE_API_KEY=xxx
        GOOGLE_GEMINI_MODEL_AGENT=gemini-2.0-flash
        GOOGLE_GEMINI_MODEL_CODEGEN=gemini-2.5-flash
    namespaceFiles:
      enabled: true
    taskRunner: 
      type: io.kestra.plugin.scripts.runner.docker.Docker
      pullPolicy: ALWAYS
    commands:
      - uv run pytest -v --durations=0 tests
 ```