### PR TITLE
fix: skip tests for disabled tools, remove tools that need superadmn access

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,5 @@
 """
-uv run pytest src/tests/test_mcp_server.py
+uv run pytest tests/test_mcp_server.py
 
 config = {
   "mcpServers": {
@@ -85,10 +85,7 @@ async def test_list_tools():
             "manage_apps",
             "manage_group",
             "manage_invitations",
-            "manage_maintenance_mode",
-            "manage_tests",
-            "manage_worker_groups",
-            "search_users",
+            "manage_tests"
         }
 
         # Check if EE tools are disabled

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,11 +8,13 @@ mcp_server_config = {
         "kestraPython": {
             "command": "uv",
             "args": [
-                "--directory",
-                "src",
                 "run",
-                "server.py",
+                "src/server.py",
             ],
+            "cwd": ".",
+            "env": {
+                "PYTHONPATH": "."
+            }
         }
     }
 }


### PR DESCRIPTION
Superadmin endpoints are dangerous and there are major differences between 0.22, 0.23, 0.24 versions - removing them for now seems best. 