### PR TITLE
fix: use text/plain Content-Type for KV store PUT endpoint

### DIFF
--- a/src/tools/kv.py
+++ b/src/tools/kv.py
@@ -52,7 +52,7 @@ def register_kv_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
             resp = await client.put(
                 f"/namespaces/{namespace}/kv/{key}",
                 content=content,
-                headers={"Content-Type": "application/json"},
+                headers={"Content-Type": "text/plain"},
             )
             resp.raise_for_status()
             return {"status": "ok"}


### PR DESCRIPTION
## Changes

Updated the Content-Type header in the KV store PUT endpoint from `application/json` to `text/plain`.

### Modified Files
- `src/tools/kv.py`: Changed Content-Type header value in the KV store PUT request