### PR TITLE
fix: use /executions/search to fix 400 on list_executions in Kestra 1.3.x

### DIFF
--- a/src/kestra/utils.py
+++ b/src/kestra/utils.py
@@ -121,7 +121,7 @@ async def get_latest_execution(
     params = {"namespace": namespace, "flowId": flow_id, "size": 25}
     if state:
         params["state"] = state
-    resp = await client.get("/executions", params=params)
+    resp = await client.get("/executions/search", params=params)
     resp.raise_for_status()
     data = resp.json()
 

--- a/src/tools/execution.py
+++ b/src/tools/execution.py
@@ -282,7 +282,7 @@ def register_execution_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
 
         # If we only need one execution, we can optimize by using a smaller page size
         if count == 1:
-            page_size = 10  # Small page size is sufficient for finding the latest
+            page_size = 25  # Minimum safe page size for the Kestra API
 
         while True:
             params: dict[str, Any] = {
@@ -293,7 +293,7 @@ def register_execution_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
             if flow_id:
                 params["flowId"] = flow_id
 
-            resp = await client.get("/executions", params=params)
+            resp = await client.get("/executions/search", params=params)
             resp.raise_for_status()
             data = resp.json()
 


### PR DESCRIPTION
Closes #14

## Summary

- Kestra 1.3.x made `flowId` a **required** query parameter on `GET /executions`, breaking `list_executions` and `get_latest_execution` with a `400 Bad Request` whenever no flow ID was specified.
- Switches both callers from `GET /executions` → `GET /executions/search`, which accepts `namespace` alone and is the correct endpoint for listing executions across all flows in a namespace.
- Also bumps the `count=1` page-size optimisation from `10` → `25` to match the minimum used elsewhere in the codebase (`get_latest_execution` already uses `size=25`).

## Root cause

\`\`\`
400 Bad Request: Required QueryValue [flowId] not specified
GET /api/v1/{tenant}/executions?namespace=company.team&page=1&size=25
\`\`\`

The \`/executions\` endpoint is scoped to a single flow; \`/executions/search\` is the namespace-wide search endpoint and has no such constraint.

## Files changed

| File | Change |
|------|--------|
| \`src/tools/execution.py\` | \`list_executions\` → \`/executions/search\`; page_size floor 10 → 25 |
| \`src/kestra/utils.py\` | \`get_latest_execution\` → \`/executions/search\` |

## Test plan

- [x] Verified \`GET /executions/search?namespace=company.team&page=1&size=25\` returns \`200 OK\` with real results against Kestra EE 1.3.10
- [x] Verified \`list_executions\` MCP tool now returns executions successfully after restart
- [ ] Run existing test suite against a Kestra 1.3.x instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)