### PR TITLE
fix(list_executions): fix time filtering, response size, and count correctness

### DIFF
--- a/src/tools/execution.py
+++ b/src/tools/execution.py
@@ -2,6 +2,7 @@ from fastmcp import FastMCP
 import httpx
 from typing import Annotated, Any, Literal, List
 from pydantic import Field
+import re
 from datetime import datetime, timedelta, timezone
 from kestra.utils import _parse_iso
 from kestra.constants import (
@@ -9,6 +10,24 @@ from kestra.constants import (
     _TERMINAL_STATES,
     _RESERVED_FLOW_IDS,
 )
+
+
+def _parse_iso_duration(duration: str) -> timedelta:
+    """Parse a simple ISO 8601 duration (PnD, PTnH, PTnM, PnDTnHnM) into a timedelta."""
+    m = re.fullmatch(
+        r"P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?",
+        duration.strip(),
+    )
+    if not m or not any(m.groups()):
+        raise ValueError(
+            f"Unsupported ISO 8601 duration: {duration!r}. "
+            "Use formats like 'P30D', 'P7D', 'PT5M', 'PT1H'."
+        )
+    days = int(m.group(1) or 0)
+    hours = int(m.group(2) or 0)
+    minutes = int(m.group(3) or 0)
+    seconds = int(m.group(4) or 0)
+    return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
 
 
 def _normalize_labels(labels) -> list[dict]:
@@ -241,15 +260,32 @@ def register_execution_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
         count: Annotated[
             int,
             Field(
-                description="Optional number of most recent executions to return. If None, returns all executions"
+                description="Optional number of most recent executions to return. If None, returns all executions within the date range."
             ),
         ] = None,
-        minutes: Annotated[
-            int,
+        time_range: Annotated[
+            str,
             Field(
-                description="Optional time window in minutes to filter executions. If None, no time filtering"
+                description=(
+                    "Relative time range as an ISO 8601 duration, e.g. 'P30D' for the last 30 days, "
+                    "'P7D' for the last 7 days, 'PT5M' for the last 5 minutes, 'PT1H' for the last hour. "
+                    "Defaults to 'P90D' (last 90 days) when no date filter is provided. "
+                    "Use start_date/end_date instead for an absolute date range."
+                )
             ),
-        ] = None,
+        ] = "",
+        start_date: Annotated[
+            str,
+            Field(
+                description="Absolute start of the date range in ISO 8601 format, e.g. '2025-04-01T00:00:00Z'. Takes precedence over time_range."
+            ),
+        ] = "",
+        end_date: Annotated[
+            str,
+            Field(
+                description="Absolute end of the date range in ISO 8601 format, e.g. '2025-04-30T23:59:59Z'. Only used with start_date."
+            ),
+        ] = "",
         page_size: Annotated[
             int,
             Field(
@@ -280,9 +316,30 @@ def register_execution_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
         all_execs: List[dict] = []
         page = 1
 
-        # If we only need one execution, we can optimize by using a smaller page size
-        if count == 1:
-            page_size = 25  # Minimum safe page size for the Kestra API
+        # Resolve the startDate sent to the API.
+        # We always compute an explicit startDate rather than relying on the API's
+        # `timeRange` query param, which (a) may not be supported as a flat param
+        # and (b) uses exact-hour arithmetic that silently excludes boundary days.
+        # For day-granularity ranges we snap to midnight so "last 10 days" includes
+        # the whole of the day 10 days ago, not just the past 240 hours.
+        now = datetime.now(timezone.utc)
+        if start_date:
+            effective_start_date = start_date
+        elif time_range:
+            delta = _parse_iso_duration(time_range)
+            point = now - delta
+            # Day-only durations (no sub-day component): snap back to midnight so the
+            # entire boundary day is included rather than just the last N*24 hours.
+            if delta.seconds == 0 and delta.microseconds == 0:
+                point = point.replace(hour=0, minute=0, second=0, microsecond=0)
+            effective_start_date = point.strftime("%Y-%m-%dT%H:%M:%SZ")
+        else:
+            # Default: start of day 90 days ago
+            effective_start_date = (
+                (now - timedelta(days=90))
+                .replace(hour=0, minute=0, second=0, microsecond=0)
+                .strftime("%Y-%m-%dT%H:%M:%SZ")
+            )
 
         while True:
             params: dict[str, Any] = {
@@ -292,6 +349,9 @@ def register_execution_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
             }
             if flow_id:
                 params["flowId"] = flow_id
+            params["startDate"] = effective_start_date
+            if end_date:
+                params["endDate"] = end_date
 
             resp = await client.get("/executions/search", params=params)
             resp.raise_for_status()
@@ -303,28 +363,39 @@ def register_execution_tools(mcp: FastMCP, client: httpx.AsyncClient) -> None:
 
             all_execs.extend(batch)
 
-            # If we have enough executions to satisfy the count requirement, we can stop
-            if count is not None and len(all_execs) >= count:
-                break
-
             # If we got fewer results than requested, we've reached the end
             if len(batch) < page_size:
                 break
 
             page += 1
 
-        # Apply time filtering if requested
-        if minutes is not None:
-            cutoff = datetime.now(timezone.utc) - timedelta(minutes=minutes)
-            all_execs = [
-                e for e in all_execs if _parse_iso(e["state"]["startDate"]) >= cutoff
-            ]
-
-        # Sort by startDate in descending order (newest first)
+        # Sort client-side — the search endpoint doesn't accept a sort param reliably
         all_execs.sort(key=lambda e: _parse_iso(e["state"]["startDate"]), reverse=True)
 
         # Return only the requested number of executions
         if count is not None:
             all_execs = all_execs[:count]
 
-        return {"results": all_execs}
+        # Trim each execution to only the fields needed — full objects include
+        # taskRunList, outputs, metadata, etc. which bloat the response significantly.
+        def _slim(e: dict) -> dict:
+            state = e.get("state", {})
+            slim: dict[str, Any] = {
+                "id": e.get("id"),
+                "namespace": e.get("namespace"),
+                "flowId": e.get("flowId"),
+                "state": {
+                    "current": state.get("current"),
+                    "startDate": state.get("startDate"),
+                    "endDate": state.get("endDate"),
+                },
+            }
+            if "durationSeconds" in e:
+                slim["durationSeconds"] = e["durationSeconds"]
+            if e.get("inputs"):
+                slim["inputs"] = e["inputs"]
+            if e.get("labels"):
+                slim["labels"] = e["labels"]
+            return slim
+
+        return {"results": [_slim(e) for e in all_execs]}

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -230,14 +230,14 @@ async def test_list_executions(kestra_client, cleanup):
         assert execution["namespace"] == "company.team"
         assert execution["flowId"] == "get_data"
 
-    # Test case 2: List two recent executions within last 15 minutes
+    # Test case 2: List two recent executions within last 1 day
     result = await kestra_client.call_tool(
         "list_executions",
         {
             "namespace": "company.team",
             "flow_id": "get_data",
             "count": 2,
-            "minutes": 15,
+            "time_range": "P1D",
         },
     )
     response_json = json.loads(result.content[0].text) if result and result.content and result.content[0].text else {}
@@ -259,12 +259,12 @@ async def test_list_executions(kestra_client, cleanup):
         for execution in executions:
             assert execution["namespace"] == "company.team"
             assert execution["flowId"] == "get_data"
-            # Verify execution is within last 15 minutes
+            # Verify execution is within last 1 day
             start_date = datetime.fromisoformat(
                 execution["state"]["startDate"].replace("Z", "+00:00")
             )
             time_diff = datetime.now(timezone.utc) - start_date
-            assert time_diff.total_seconds() <= 15 * 60  # 15 minutes in seconds
+            assert time_diff.total_seconds() <= 24 * 60 * 60  # 1 day in seconds
 
     # Test case 3: List latest execution
     result = await kestra_client.call_tool(
@@ -421,7 +421,7 @@ async def test_execute_flow_with_subflow(kestra_client, cleanup):
     while retry_count < max_retries and subflow_execution_id is None:
         result = await kestra_client.call_tool(
             "list_executions",
-            {"namespace": "company.team", "flow_id": "hello_mcp", "minutes": 5},
+            {"namespace": "company.team", "flow_id": "hello_mcp", "time_range": "PT5M"},
         )
         response_json = (
             json.loads(result.content[0].text) if result and result.content and result.content[0].text else {}


### PR DESCRIPTION
## Summary

- **Time filtering was broken**: `list_executions` used a `minutes` param that applied client-side after pagination — so when paginating stopped early (due to `count`), recent executions were silently excluded. Fixed by pushing `startDate`/`endDate` to the API as query params.
- **`count=1` returned wrong result**: An early-break optimization stopped pagination after the first page; since the API returns results oldest-first, sorting those gave the oldest-of-the-first-page, not the actual most recent execution. Removed the early-break so all pages are fetched before sorting.
- **Boundary day exclusion**: `P10D` was computed as "now minus 240 hours", excluding executions on the boundary day before the cutoff time. Day-granularity durations now snap to midnight so the full boundary day is included.
- **422 error from invalid `sort` param**: The API expects `sort` as an array, not a string — passing it as `"state.startDate,desc"` caused a 422 Unprocessable Entity. Removed `sort` from query params; client-side sort handles ordering.
- **Response payload bloat**: Full execution objects include `taskRunList`, `outputs`, `metadata`, etc. Added `_slim()` to strip each object to only the 7 fields needed (id, namespace, flowId, state, durationSeconds, inputs, labels).
- **LLM-friendly date params**: Replaced the error-prone `minutes: int` param with `time_range: str` (ISO 8601 duration e.g. `P30D`, `PT5M`) and added `start_date`/`end_date` for absolute ranges.

## What changed

- `src/tools/execution.py`: Added `_parse_iso_duration()` helper; rewrote date resolution logic in `list_executions`; removed `sort` and `timeRange` from API params; removed count early-break; added `_slim()` for response trimming
- `tests/test_execution.py`: Updated `minutes` → `time_range` param in two test cases

## Reviewer notes

The `count` early-break was an intentional optimization to avoid fetching all pages when only a few results are needed. It's been removed because correctness trumps efficiency here — the API has no reliable server-side sort, so we must fetch all pages to guarantee newest-first ordering. If performance becomes an issue with large namespaces, a future PR could explore using a tighter default `time_range` when `count` is small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)